### PR TITLE
Fix Bash syntax in tests/silent.sh

### DIFF
--- a/unix/lang/tests/silent.sh
+++ b/unix/lang/tests/silent.sh
@@ -5,7 +5,7 @@
 #
 OUT=`./yabasic tests/resources/silent.yab 2>&1`
 echo "$OUT"
-if [ "$OUT" -ne "" ]; then
+if [ -n "$OUT" ]; then
     exit 1
 else
     exit 0

--- a/unix/lang/tests/silent.sh
+++ b/unix/lang/tests/silent.sh
@@ -4,8 +4,8 @@
 # Check, if empty yabasic-program produces any warning
 #
 OUT=`./yabasic tests/resources/silent.yab 2>&1`
-echo $OUT
-if [ $OUT -ne "" ]; then
+echo "$OUT"
+if [ "$OUT" -ne "" ]; then
     exit 1
 else
     exit 0


### PR DESCRIPTION
`silent.sh` uses the numeric comparison operator `-ne` to compare the results of running a Basic file, which it does not quote, to the empty string. If the result is the empty string, this always prints the error "-ne: unary operator expected" and evaluates to "false" (causing the test-case to spuriously pass); if it is not, Bash treats the two strings as numbers somehow for the comparison.

This pull request contains two patches. The first quotes the variable containing the output, and the second changes the test from a binary numeric-equality test `-ne` to the unary string-emptiness test `-n`.

(I discovered this while investigating what *may* have been issue #22.)